### PR TITLE
Test without cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,40 +20,6 @@ testbase:
 	sed -i -e 's/TAG/openvas_base/g' ./test/Dockerfile
 	docker build -t mikesplain/openvas:testbase ./test
 	sed -i -e 's/openvas_base/TAG/g' ./test/Dockerfile
-	docker run -d -p 443:443 -p 9390:9390 -p 9391:9391 -v $(HOME)/openvas:/usr/local/var/lib/openvas --name testbase mikesplain/openvas:testbase
-	until docker logs --tail 50 testbase 2>&1 | grep -E 'Data Base Updated'; do \
-		echo "Waiting for script completion..." ; \
-		sleep 30 ; \
-	done
-	echo "Done."
-	echo "Waiting for startup to complete."
-	until ps aux | grep -v grep | grep -E 'openvassd: Reloaded'; do \
-		echo "." ; \
-		sleep 2 ; \
-	done
-	echo "NVTs loading. Waiting to complete"
-	while ps aux | grep -v grep | grep -E 'openvassd: Reloaded'; do \
-		echo "." ; \
-		sleep 2 ; \
-	done
-	echo "NVTs done loading. Resting a moment"
-	sleep 2
-	echo "Rebuilding."
-	while ps aux | grep -v grep | grep -E 'openvasmd: Rebuilding'; do \
-		echo "." ; \
-		sleep 2 ; \
-	done
-	echo "Testbase logs:"
-	docker logs --tail 50 testbase 2>&1
-	echo "Attempting login"
-	docker-ssh testbase /openvas-check-setup >> ~/check_setup.log
-	if grep -E 'It seems like your OpenVAS-7 installation is OK' ~/check_setup.log; \
-	then \
-		echo "Setup Successfully!" ; \
-	else \
-		echo "Setup failure" ; \
-		exit 1 ; \
-	fi
 
 testfull:
 	cp -R ~/openvas openvas_full/
@@ -64,32 +30,6 @@ testfull:
 	git checkout openvas_full/Dockerfile
 	sed -i -e 's/TAG/openvas:full/g' ./test/Dockerfile
 	docker build -t mikesplain/openvas:testfull ./test
-	docker run -d -p 443:443 -p 9390:9390 -p 9391:9391 -v $(HOME)/openvas:/usr/local/var/lib/openvas --name testfull mikesplain/openvas:testfull
-	echo "Waiting for startup to complete."
-	until ps aux | grep -v grep | grep -E 'openvassd: Reloaded'; do \
-		echo "." ; \
-		sleep 2 ; \
-	done
-	echo "NVTs loading. Waiting to complete"
-	while ps aux | grep -v grep | grep -E 'openvassd: Reloaded'; do \
-		echo "." ; \
-		sleep 2 ; \
-	done
-	echo "NVTs done loading. Resting a moment"
-	sleep 2
-	echo "Rebuilding."
-	while ps aux | grep -v grep | grep -E 'openvasmd: Rebuilding'; do \
-		echo "." ; \
-		sleep 2 ; \
-	done
-	docker-ssh testfull /openvas-check-setup >> ~/check_setup.log
-	if grep -E 'It seems like your OpenVAS-7 installation is OK' ~/check_setup.log; \
-	then \
-		echo "Setup Successfully!" ; \
-	else \
-		echo "Setup failure" ; \
-		exit 1 ; \
-	fi
 
 clean: cleanup
 

--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,6 @@ testbase:
 	sed -i -e 's/openvas_base/TAG/g' ./test/Dockerfile
 
 testfull:
-	cp -R ~/openvas openvas_full/
-	sed -i~ '3s/^/ADD openvas \/usr\/local\/var\/lib\/openvas/' openvas_full/Dockerfile
-	sed -i -e '14,15d' openvas_full/Dockerfile
-	sed -i~ '13s/ \&\& \\//' openvas_full/Dockerfile
 	docker build -t mikesplain/openvas:full openvas_full
 	git checkout openvas_full/Dockerfile
 	sed -i -e 's/TAG/openvas:full/g' ./test/Dockerfile

--- a/circle.yml
+++ b/circle.yml
@@ -3,10 +3,6 @@ machine:
     - docker
 
 dependencies:
-  cache_directories:
-    - "~/openvas"
-  pre:
-    - cd ~ && wget http://s3.mikespla.in/openvas/data.tar.gz && tar -zxvf data.tar.gz && rm -rf data.tar.gz
   override:
     - curl --fail -L -O https://github.com/phusion/baseimage-docker/archive/master.tar.gz && tar xzf master.tar.gz && sudo ./baseimage-docker-master/install-tools.sh
     - docker build --no-cache -t mikesplain/openvas_base openvas_base:


### PR DESCRIPTION
The goal of this PR is to remove the cache, clean up the make file for now so we can get accurate builds going in circleci.

I'll circle back later and restructure the testing since this is just not working.

Next step will be to get an OpenVAS 8 build going so we can have openvas 7 and 8.