### PR TITLE
disable weak ciphers in GSAD

### DIFF
--- a/openvas_base/bin/gsad
+++ b/openvas_base/bin/gsad
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec gsad -f
+exec gsad --gnutls-priorities="SECURE128:-AES-128-CBC:-CAMELLIA-128-CBC:-VERS-SSL3.0:-VERS-TLS1.0 -f


### PR DESCRIPTION
http://wiki.openvas.org/index.php/Edit_the_SSL_ciphers_used_by_GSAD