### PR TITLE
Added env variables to override Web UI HTTPS certs

### DIFF
--- a/9/start
+++ b/9/start
@@ -2,6 +2,12 @@
 
 DATAVOL=/var/lib/openvas/mgr/
 OV_PASSWORD=${OV_PASSWORD:-admin}
+WEB_CERT_FILE=${WEB_CERT_FILE:-""}
+WEB_KEY_FILE=${WEB_KEY_FILE:-""}
+
+if [ ! -z "$WEB_CERT_FILE" -a ! -z "$WEB_KEY_FILE" ]; then 
+        echo 'DAEMON_ARGS="--mlisten 127.0.0.1 -m 9390 -k '$WEB_KEY_FILE' -c '$WEB_CERT_FILE'"' >> /etc/default/openvas-gsa
+fi
 
 redis-server /etc/redis/redis.conf
 


### PR DESCRIPTION
Users might want to add their own certificate for the web interface.
The 'start' script has been modified to consider:
 * WEB_CERT_FILE: the location of the certificate on the file system
 * WEB_KEY_FILE: the location of the key on the file system

It is users' responsibility to make sure that those files exist (either
with volumes mounts or with a custom image adding those files)