### PR TITLE
Disable insecure HTTPS ciphers

### DIFF
--- a/9/Dockerfile
+++ b/9/Dockerfile
@@ -59,7 +59,7 @@ RUN mkdir -p /var/run/redis && \
       -O /openvas-check-setup && \
     chmod +x /openvas-check-setup && \
     sed -i 's/DAEMON_ARGS=""/DAEMON_ARGS="-a 0.0.0.0"/' /etc/init.d/openvas-manager && \
-    sed -i 's/DAEMON_ARGS=""/DAEMON_ARGS="--mlisten 127.0.0.1 -m 9390"/' /etc/init.d/openvas-gsa && \
+    sed -i 's/DAEMON_ARGS=""/DAEMON_ARGS="--mlisten 127.0.0.1 -m 9390 --gnutls-priorities=SECURE128:-AES-128-CBC:-CAMELLIA-128-CBC:-VERS-SSL3.0:-VERS-TLS1.0"/' /etc/init.d/openvas-gsa && \
     sed -i 's/PORT_NUMBER=4000/PORT_NUMBER=443/' /etc/default/openvas-gsa && \
     greenbone-nvt-sync && \
     greenbone-scapdata-sync && \


### PR DESCRIPTION
When scanning the host that OpenVAS is running on, it reports vulnerable HTTPS ciphers (3DES) that are enabled in GSAD. This fix disables them.