### PR TITLE
add ldap admin user sync feature

### DIFF
--- a/9/Dockerfile
+++ b/9/Dockerfile
@@ -2,6 +2,8 @@ FROM ubuntu:16.04
 
 ADD config/redis.config /etc/redis/redis.config
 ADD start /start
+ADD ldapUserSync/* /ldapUserSync/
+
 
 ENV DEBIAN_FRONTEND=noninteractive \
     OV_PASSWORD=admin
@@ -35,6 +37,7 @@ RUN apt-get update && \
                     w3af \
                     wapiti \
                     wget \
+                    ldap-utils \
                     -yq && \
     apt-get purge \
         texlive-pstricks-doc \

--- a/9/ldapUserSync/config.py
+++ b/9/ldapUserSync/config.py
@@ -1,0 +1,12 @@
+config = {
+    # LDAP configuration
+    'ldap_host' : 'YOUR HOST',
+    'ldap_bind' : 'uid=bindUid,cn=sysaccounts,dc=company,dc=com',
+    'ldap_base' : 'cn=accounts,dc=company,dc=com',
+    'ldap_admin_filter' : 'memberOf=cn=admins,cn=groups,cn=accounts,dc=company,dc=com',
+    'ldap_password' : 'password',
+    'ldap_username_attr' : 'uid',
+
+    # OpenVAS configuration
+    'ov_password' : 'admin'
+}

--- a/9/ldapUserSync/ldapUserSync.py
+++ b/9/ldapUserSync/ldapUserSync.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+# encoding: utf-8
+"""
+ldapUserSync.py
+This little script will sync ldap admin user with openvas user. A work around to openvas per-user ldap limitation
+Created by lhan on 2015-07-17.
+"""
+import os
+import sys
+import getopt
+import shlex
+import subprocess
+from sets import Set 
+from config import config
+from os import environ
+
+
+def get_config(key):
+    try:
+        envKey = key.upper()
+        value = environ[envKey]
+    except:
+        value = config.get(key)
+    return value
+
+help_message = '''
+Sync admin user from ldap to openvas
+'''
+# LDAP Configuration
+host = get_config('ldap_host')
+bindDN = get_config('ldap_bind_dn')
+baseDN = get_config('ldap_base_dn')
+ldapFilter = get_config('ldap_admin_filter')
+ldapPwd = get_config('ldap_password') 
+
+# OpenVAS configuration
+ovUser = 'admin'
+ovPwd = get_config('ov_password')
+
+ADMIN_ROLE_ID = '7a8cb5b4-b74d-11e2-8187-406186ea4fc5'
+UID_ATT = get_config('ldap_username_attr')
+
+
+ldapUsers = Set([])
+ovUsers = Set([])
+
+# Utils
+BASH = lambda x: (subprocess.Popen(shlex.split(x), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False).communicate()[0])
+
+
+class Usage(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv
+    try:
+        try:
+            opts, args = getopt.getopt(argv[1:], "hv:H:D:b:w:f:u:W:", ["help",  "host=", "bind=", "base=", "ldap-pass=", "ldap-filter=", "username=", "password="])
+        except getopt.error, msg:
+            raise Usage(msg)
+    
+        # option processing
+        for option, value in opts:
+            if option == "-v":
+                verbose = True
+            if option in ("-h", "--help"):
+                raise Usage(help_message)
+            # ldap host
+            if option in ("-H", "--host"):
+                global host
+                host = value
+            # ldap bindDN(-D)
+            if option in ("-D", "--bind"):
+                global bindDN
+                bindDN = value
+            # ldap baseDN(-b)
+            if option in ("-b", "--base"):
+                global baseDN
+                baseDN = value
+            # ldap password(-w)
+            if option in ("-w", "--ldap-pass"):
+                global ldapPwd
+                ldapPwd = value
+            # filter(-f)
+            if option in ("-f", "--ldap-filter"):
+                global ldapFilter
+                ldapFilter = value
+            # openvas username (-u)
+            if option in ("-u", "--username"):
+                global ovUser
+                ovUser = value
+            # openvas password(-W)
+            if option in ("-W", "--password"):
+                global ovPwd
+                ovPwd = value
+    except Usage, err:
+        print >> sys.stderr, sys.argv[0].split("/")[-1] + ": " + str(err.msg)
+        print >> sys.stderr, "\t for help use --help"
+        return 2
+    syncUsers()
+
+def getLdapUser():
+    global ldapUsers
+    if len(ldapUsers) == 0:
+        ldapUsersCmd = "ldapsearch -H ldaps://%s -D %s -b %s -w %s \'(%s)\' %s"%(host, bindDN, baseDN, ldapPwd, ldapFilter, UID_ATT)
+        ldapUsersCmdResponse = BASH(ldapUsersCmd)
+        uidAttrP = '%s: '%(UID_ATT)
+        for line in ldapUsersCmdResponse.split('\n'):
+            if line.find(uidAttrP) != -1 :
+                ldapUsers.add(line.split(uidAttrP)[1])
+    return ldapUsers
+    
+def getOpenVasUsers():
+    global ovUsers
+    if len(ovUsers) == 0:
+        ovUsersCmd =  "openvasmd --get-users"
+        ovUsersCmdResponse = BASH(ovUsersCmd)
+        for line in ovUsersCmdResponse.split('\n'):
+            if len(line) > 0:
+                ovUsers.add(line)
+        
+    return ovUsers
+
+def createUser(userName):
+    cmd = '''omp -u %s -w %s -X "<create_user><name>%s</name><role id='%s'/><sources><source>ldap_connect</source></sources></create_user>"'''%(ovUser, ovPwd, userName, ADMIN_ROLE_ID)
+    resp = BASH(cmd)
+    if resp.find("OK, resource created") != -1:
+        print "Sucess to create user %s"%(userName)
+        return True
+    else:
+        print "Fail to create user %s: %s"%(userName, resp)
+        return False
+
+def syncUsers():
+    ldapUsers = getLdapUser()
+    ovUsers = getOpenVasUsers()
+    usersToCreate = ldapUsers - ovUsers
+    map(createUser, usersToCreate)
+    
+if __name__ == "__main__":
+    sys.exit(main())

--- a/9/start
+++ b/9/start
@@ -37,6 +37,61 @@ if [ -n "$SETUPUSER" ]; then
   /usr/sbin/openvasmd --user=admin --new-password=$OV_PASSWORD
 fi
 
+#
+# CA configuration (optional)
+#
+# Varaibles:
+# - CA_CERT
+# - CA_CERTS_DIR
+i=0
+# Add CA certs to the system if they are defined
+if [[ -n "$CA_CERT" && -e "$CA_CERT" ]]
+then
+  CA_CERTS_TO_ADD[((i++))]="$CA_CERT"
+fi
+
+
+if [[ -n "$CA_CERTS_DIR" && -e "$CA_CERTS_DIR" ]]
+then
+  for cert in `find $CA_CERTS_DIR -type f \( -iname \*.crt -o -iname \*.pem \)`
+  do
+    CA_CERTS_TO_ADD[((i++))]="$cert"
+  done
+fi
+
+for (( i = 0; i < ${#CA_CERTS_TO_ADD[@]}; i++))
+do
+  echo "Importing ${CA_CERTS_TO_ADD[${i}]} to system keystore as ${CA_CERTS_TO_ADD[${i}]##*/}"
+  cp ${CA_CERTS_TO_ADD[${i}]} /usr/local/share/ca-certificates/
+done
+
+if [ "$i" -gt "0" ]
+then
+  update-ca-certificates
+fi
+
+#
+# LDAP configuration (optional)
+#
+# Varaibles:
+# - LDAP_HOST
+# - LDAP_BIND_DN
+# - LDAP_BASE_DN 
+# - LDAP_AUTH_DN
+# - LDAP_ADMIN_FILTER
+# - LDAP_PASSWORD
+# - LDAP_USERNAME_ATTR 
+if [ -n "$LDAP_HOST" ] &&
+    [ -n "$LDAP_BIND_DN" ] &&
+    [ -n "$LDAP_BASE_DN" ] &&
+    [ -n "$LDAP_AUTH_DN" ] &&
+    [ -n "$LDAP_ADMIN_FILTER" ] &&
+    [ -n "$LDAP_PASSWORD" ]
+then
+  echo "Syncing Ldap admin users to openVAS..."
+  /ldapUserSync/ldapUserSync.py
+fi
+
 echo "Checking setup"
 ./openvas-check-setup --v9
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ greenbone-nvt-sync
 openvasmd --rebuild --progress
 ```
 #### LDAP Support
-A simple script was added to sync ldap admin user(defined by `LDAP_ADMIN_FILTER `) with openvas admin users. This is owing to openvas not support full ldap integration but only per-user authentication. To enable this, please specify the required ldap env variables:
+Openvas do not support full ldap integration but only per-user authentication. A workaround is in place here by syncing ldap admin user(defined by `LDAP_ADMIN_FILTER `) with openvas admin users everytime the app start up.  To use this, just need to specify the required ldap env variables:
 ```
 docker run -d -p 443:443 -p 9390:9390 --name openvas -e LDAP_HOST=your.ldap.host -e LDAP_BIND_DN=uid=binduid,dc=company,dc=com -e LDAP_BASE_DN=cn=accounts,dc=company,dc=com -e LDAP_AUTH_DN=uid=%s,cn=users,cn=accounts,dc=company,dc=com -e LDAP_ADMIN_FILTER=memberOf=cn=admins,cn=groups,cn=accounts,dc=company,dc=com -e LDAP_PASSWORD=password -e OV_PASSWORD=admin mikesplain/openvas 
 ```

--- a/README.md
+++ b/README.md
@@ -76,7 +76,11 @@ docker exec -it openvas bash
 greenbone-nvt-sync
 openvasmd --rebuild --progress
 ```
-
+#### LDAP Support
+A simple script was added to sync ldap admin user(defined by `LDAP_ADMIN_FILTER `) with openvas admin users. This is owing to openvas not support full ldap integration but only per-user authentication. To enable this, please specify the required ldap env variables:
+```
+docker run -d -p 443:443 -p 9390:9390 --name openvas -e LDAP_HOST=your.ldap.host -e LDAP_BIND_DN=uid=binduid,dc=company,dc=com -e LDAP_BASE_DN=cn=accounts,dc=company,dc=com -e LDAP_AUTH_DN=uid=%s,cn=users,cn=accounts,dc=company,dc=com -e LDAP_ADMIN_FILTER=memberOf=cn=admins,cn=groups,cn=accounts,dc=company,dc=com -e LDAP_PASSWORD=password -e OV_PASSWORD=admin mikesplain/openvas 
+```
 
 Contributing
 ------------


### PR DESCRIPTION
## What this PR do?

Although Openvas support ldap authentication, the ldap user had to be existing first. This PR solve this limitation by syncing the admin user between ldap and openvas each time before service start. (User can filter the scope of admin by specifying `LDAP_ADMIN_FILTER` env variable.)

Please note: To be able to secure LDAP connection, proper CA certificates may need to be imported by specifying `CA_CERT`(the path to a single CA cert)/ `CA_CERTS_DIR`(the path to the dir of CA certs) env variables

## Examples

ldap sync support with secure LDAP connection. (these features will only enable when required env variables are given)
```
docker run -d -p 8443:443 -v $(pwd)/openvas:/var/lib/openvas/mgr/ --name openvas -e LDAP_HOST=name.your.ldap.host.com -e LDAP_BIND_DN=uid=bind,dc=your,dc=company,dc=com -e LDAP_BASE_DN=cn=accounts,dc=your,dc=company,dc=com -e LDAP_AUTH_DN=uid=%s,cn=users,cn=accounts,dc=your,dc=company,dc=com -e LDAP_PASSWORD=password -e LDAP_ADMIN_FILTER=memberOf=cn=admins,cn=accounts,dc=your,dc=company,dc=com -e LDAP_USERNAME_ATTR=uid -v $(pwd)/ca.crt:/openvas/certs/ca.crt -e CA_CERT=/openvas/certs/ca.crt openvas 
``` 
 