### PR TITLE
Supporting eternal certificates and removing insecure HTTPS ciphers

### DIFF
--- a/9/Dockerfile
+++ b/9/Dockerfile
@@ -59,7 +59,7 @@ RUN mkdir -p /var/run/redis && \
       -O /openvas-check-setup && \
     chmod +x /openvas-check-setup && \
     sed -i 's/DAEMON_ARGS=""/DAEMON_ARGS="-a 0.0.0.0"/' /etc/init.d/openvas-manager && \
-    sed -i 's/DAEMON_ARGS=""/DAEMON_ARGS="--mlisten 127.0.0.1 -m 9390"/' /etc/init.d/openvas-gsa && \
+    sed -i 's/DAEMON_ARGS=""/DAEMON_ARGS="--mlisten 127.0.0.1 -m 9390 --gnutls-priorities=SECURE128:-AES-128-CBC:-CAMELLIA-128-CBC:-VERS-SSL3.0:-VERS-TLS1.0"/' /etc/init.d/openvas-gsa && \
     sed -i 's/PORT_NUMBER=4000/PORT_NUMBER=443/' /etc/default/openvas-gsa && \
     greenbone-nvt-sync && \
     greenbone-scapdata-sync && \

--- a/9/start
+++ b/9/start
@@ -6,7 +6,10 @@ WEB_CERT_FILE=${WEB_CERT_FILE:-""}
 WEB_KEY_FILE=${WEB_KEY_FILE:-""}
 
 if [ ! -z "$WEB_CERT_FILE" -a ! -z "$WEB_KEY_FILE" ]; then 
-        echo 'DAEMON_ARGS="--mlisten 127.0.0.1 -m 9390 -k '$WEB_KEY_FILE' -c '$WEB_CERT_FILE'"' >> /etc/default/openvas-gsa
+        rm -f /var/lib/openvas/CA/servercert.pem
+        rm -f /var/lib/openvas/private/CA/serverkey.pem
+        ln -s "$WEB_CERT_FILE" /var/lib/openvas/CA/servercert.pem
+        ln -s "$WEB_KEY_FILE" /var/lib/openvas/private/CA/serverkey.pem
 fi
 
 redis-server /etc/redis/redis.conf


### PR DESCRIPTION
Use symlinks to prevent conflicts between #132 and modification to remove insecure HTTPS ciphers.