### PR TITLE
Don't use service command to run init.d scripts

### DIFF
--- a/9/start
+++ b/9/start
@@ -27,9 +27,9 @@ echo "Checking for empty volume"
 [ -e "$DATAVOL/tasks.db" ] || SETUPUSER=true
 
 echo "Restarting services"
-service openvas-scanner restart
-service openvas-manager restart
-service openvas-gsa restart
+/etc/init.d/openvas-scanner restart
+/etc/init.d/openvas-manager restart
+/etc/init.d/openvas-gsa restart
 
 echo "Reloading NVTs"
 openvasmd --rebuild --progress


### PR DESCRIPTION
Fixes #167 by enabling environment variables to propagate to init.d scripts.