### PR TITLE
init.d/openvas-gsa: don't use PUBLIC_HOSTNAME until defaults are sourced

### DIFF
--- a/9/Dockerfile
+++ b/9/Dockerfile
@@ -67,7 +67,7 @@ RUN mkdir -p /var/run/redis && \
     chmod +x /openvas-check-setup && \
     sed -i 's/DAEMON_ARGS=""/DAEMON_ARGS="-a 0.0.0.0"/' /etc/init.d/openvas-manager && \
     sed -i 's/DAEMON_ARGS=""/DAEMON_ARGS="--mlisten 127.0.0.1 -m 9390 --gnutls-priorities=SECURE128:-AES-128-CBC:-CAMELLIA-128-CBC:-VERS-SSL3.0:-VERS-TLS1.0"/' /etc/init.d/openvas-gsa && \
-    sed -i '/^DAEMON_ARGS="/aDAEMON_ARGS="$DAEMON_ARGS --allow-header-host=$PUBLIC_HOSTNAME"' /etc/init.d/openvas-gsa && \
+    sed -i '/^\[ -n "$HTTP_STS_MAX_AGE" \]/a[ -n "$PUBLIC_HOSTNAME" ] && DAEMON_ARGS="$DAEMON_ARGS --allow-header-host=$PUBLIC_HOSTNAME"' /etc/init.d/openvas-gsa && \
     sed -i 's/PORT_NUMBER=4000/PORT_NUMBER=443/' /etc/default/openvas-gsa && \
     greenbone-nvt-sync > /dev/null && \
     greenbone-scapdata-sync > /dev/null && \


### PR DESCRIPTION
The /etc/default/openvas-gsa file doesn't get sourced until after the PUBLIC_HOSTNAME variable is already referenced; no references to environment variables should show up before this happens.