### PR TITLE
Add data from previous containers to speed up sync

### DIFF
--- a/9/Dockerfile
+++ b/9/Dockerfile
@@ -1,5 +1,10 @@
+# Start by pulling down our existing container
+# to sync 1.9 Gb of data from OpenVAS.
+FROM mikesplain/openvas
+
 FROM ubuntu:16.04
 
+COPY --from=0 /var/lib/openvas /var/lib/openvas
 COPY config/redis.config /etc/redis/redis.config
 COPY config/sasl_passwd_template /
 COPY config/main.cf_template /


### PR DESCRIPTION
This should speed up things up and prevent us from getting banned from the feeds.