### PR TITLE
Fix source for openvas-check-setup and sqlite timeout failures

### DIFF
--- a/9/Dockerfile
+++ b/9/Dockerfile
@@ -518,10 +518,10 @@ RUN wget -q https://github.com/Arachni/arachni/releases/download/v1.5.1/arachni-
 
 RUN mkdir -p /var/run/redis && \
     wget -q --no-check-certificate \
-    https://svn.wald.intevation.org/svn/openvas/branches/tools-attic/openvas-check-setup \
+    https://raw.githubusercontent.com/kurobeats/OpenVas-Management-Scripts/master/openvas-check-setup \
       -O /openvas-check-setup && \
     chmod +x /openvas-check-setup && \
-    sed -i 's/DAEMON_ARGS=""/DAEMON_ARGS="-a 0.0.0.0"/' /etc/init.d/openvas-manager && \
+    sed -i 's/DAEMON_ARGS=""/DAEMON_ARGS="-a 0.0.0.0 --client-watch-interval=0"/' /etc/init.d/openvas-manager && \
     sed -i 's/DAEMON_ARGS=""/DAEMON_ARGS="--mlisten 127.0.0.1 -m 9390 --gnutls-priorities=SECURE128:-AES-128-CBC:-CAMELLIA-128-CBC:-VERS-SSL3.0:-VERS-TLS1.0"/' /etc/init.d/openvas-gsa && \
     sed -i '/^\[ -n "$HTTP_STS_MAX_AGE" \]/a[ -n "$PUBLIC_HOSTNAME" ] && DAEMON_ARGS="$DAEMON_ARGS --allow-header-host=$PUBLIC_HOSTNAME"' /etc/init.d/openvas-gsa && \
     sed -i 's/PORT_NUMBER=4000/PORT_NUMBER=443/' /etc/default/openvas-gsa && \


### PR DESCRIPTION
`openvas-check-setup` is no longer at the old repo, but is available elsewhere via Github.

As has been reported, the current Ubuntu distro of greenbone-mgr, when running jobs, is timing out sqlite connection too quickly and is thus causing login failures, etc. The reported fix is to edit the daemon to include `--client-watch-interval=0` in the `DAEMON_ARGS`. (Ref: https://community.greenbone.net/t/openvasmd-authentication-error-after-starting-big-task/1365/21)