### PR TITLE
Fixed Letsencrypt "Fake LE Intermediate X1" and GAS hostname problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ To run:
   * [conf/nginx.conf](conf/nginx.conf)
   * [conf/nginx_ssl.conf](conf/nginx_ssl.conf)
 * Uncomment PUBLIC_HOSTNAME and set it to your real hostname
-* Change "STAGING" to 1 oncee you're sure your deploy is OK, in order to get real certs.
+* Change "STAGING" to 0 oncee you're sure your deploy is OK, in order to get real certs.
 * Change the "OV_PASSWORD" enviromental variable in [docker-compose.yml](docker-compose.yml)
 * Install the latest [docker-compose](https://docs.docker.com/compose/install/)
 * run `docker-compose up -d`

--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ To configure the postfix server, provide the following env variables at runtime:
 docker run -d -p 443:443 -e OV_SMTP_HOSTNAME=smtp.example.com -e OV_SMTP_PORT=587 -e OV_SMTP_USERNAME=username@example.com -e OV_SMTP_KEY=g0bBl3de3Go0k --name openvas mikesplain/openvas
 ```
 
+#### Troubleshooting
+
+```
+"The request contained an unknown or invalid Host header. If you are trying to access GSA via its hostname or a proxy, make sure GSA is set up to allow it."
+```
+
+Change the ALLOW_HEADER_HOST in config/openvas-gsa to allow host requests on headers.
+
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ To run:
   * [docker-compose.yml](docker-compose.yml)
   * [conf/nginx.conf](conf/nginx.conf)
   * [conf/nginx_ssl.conf](conf/nginx_ssl.conf)
-* Add the PUBLIC_HOSTNAME directive inside Openvas -> Environment definition with your hostname
-* Add the "STAGING: 0" directive inside Letsencrypt -> Ennvironment definition in order to get a real Letsencrypt certificate.
+* Uncomment PUBLIC_HOSTNAME and set it to your real hostname
+* Change "STAGING" to 1 oncee you're sure your deploy is OK, in order to get real certs.
 * Change the "OV_PASSWORD" enviromental variable in [docker-compose.yml](docker-compose.yml)
 * Install the latest [docker-compose](https://docs.docker.com/compose/install/)
 * run `docker-compose up -d`

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ To run:
   * [docker-compose.yml](docker-compose.yml)
   * [conf/nginx.conf](conf/nginx.conf)
   * [conf/nginx_ssl.conf](conf/nginx_ssl.conf)
+* Add the PUBLIC_HOSTNAME directive inside Openvas -> Environment definition with your hostname
+* Add the "STAGING: 0" directive inside Letsencrypt -> Ennvironment definition in order to get a real Letsencrypt certificate.
 * Change the "OV_PASSWORD" enviromental variable in [docker-compose.yml](docker-compose.yml)
 * Install the latest [docker-compose](https://docs.docker.com/compose/install/)
 * run `docker-compose up -d`

--- a/conf/openvas-gsa
+++ b/conf/openvas-gsa
@@ -1,0 +1,86 @@
+# Defaults for Greenbone Security Assistant initscript
+# sourced by /etc/init.d/openvas-gsa
+# installed at /etc/default/openvas-gsa by the maintainer scripts
+
+# For more information see `man gsad`
+
+# To run in foreground
+#
+#FOREGROUND=1
+
+# To disable HTTPS:
+#
+#HTTP_ONLY=1
+
+# To allow <host> as hostname/address part of a Host header:
+#
+#ALLOW_HEADER_HOST=example.com
+
+# To set listening address:
+# 
+#LISTEN_ADDRESS="0.0.0.0"
+
+# To set listening port number:
+#
+PORT_NUMBER=443
+
+# To set manager address
+#
+#MANAGER_ADDRESS="127.0.0.1"
+
+# To set manager port number
+#
+#MANAGER_PORT_NUMBER=9390
+
+# To set HTTP redirect port number
+#
+#REDIRECT_PORT=
+
+# To enable http redirection:
+#
+#HTTP_REDIRECT=1
+
+# To set SSL private key path
+#
+#SSL_PRIVATE_KEY=
+
+# To set SSL certificate path
+#
+#SSL_CERTIFICATE=
+
+# To set chroot
+#
+#DO_CHROOT=1
+
+# To set GNUTLS priorities string
+#
+#GNUTLS_PRIORITIES=
+
+# To set Diffie-Hellman parameters file path
+#
+#DH_PARAMS=
+
+# To set unix socket file path
+#
+#UNIX_SOCKET=
+
+# To set verbose
+#
+#VERBOSE=1
+
+# To set HTTP frame options string
+#
+#HTTP_FRAME_OPTS=
+
+# To set HTTP csp header string
+#
+#HTTP_CSP=
+
+# To set HSTS header
+#
+#HTTP_STS=1
+
+# To set HSTS max-age time (seconds)
+#
+#HTTP_STS_MAX_AGE=31536000
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,11 +49,19 @@ services:
       expose:
         - "443"
       volumes:
-        - "./data/openvas:/var/lib/openvas/mgr/"
+        - ./data/openvas:/var/lib/openvas/mgr/
+        #- ./conf/openvas-gsa:/etc/default/openvas-gsa
       environment:
         # CHANGE THIS !
-        OV_PASSWORD: securepassword41
+        SETUPUSER: "true"
+        OV_PASSWORD: 123mambomygoodpass
+        #DOMING CONFIG
         #PUBLIC_HOSTNAME: example.com
+        #SMPT CONFIG
+        #OV_SMTP_HOSTNAME: smtp.myfancydomain.com
+        #OV_SMTP_PORT: 587
+        #OV_SMTP_USERNAME: me@myfancydomain.com
+        #OV_SMTP_KEY: 123mambomygoodpass
       labels:
          deck-chores.dump.command: sh -c "greenbone-nvt-sync; openvasmd --rebuild --progress"
          deck-chores.dump.interval: daily

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
         WEBROOT_PATH: /tmp/letsencrypt
         EXP_LIMIT: 30
         CHECK_FREQ: 30
+        STAGING: 1
   openvas:
       restart: always
       image: mikesplain/openvas
@@ -52,6 +53,7 @@ services:
       environment:
         # CHANGE THIS !
         OV_PASSWORD: securepassword41
+        #PUBLIC_HOSTNAME: example.com
       labels:
          deck-chores.dump.command: sh -c "greenbone-nvt-sync; openvasmd --rebuild --progress"
          deck-chores.dump.interval: daily

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
         - "443"
       volumes:
         - ./data/openvas:/var/lib/openvas/mgr/
-        #- ./conf/openvas-gsa:/etc/default/openvas-gsa
+        - ./conf/openvas-gsa:/etc/default/openvas-gsa
       environment:
         # CHANGE THIS !
         SETUPUSER: "true"


### PR DESCRIPTION
- Letsencrypt fake certs: once you deploy your installation and don't use the "staging" option inside Letsncrypt container you'll obtain a fake self certificate. Setting staging to 0 fix this behaviour.

- GAS header problem: is not enough to change mentioned "example.com" strings, also needed to add "PUBLIC_HOSTNAME" to environment inside Openvas definition should be done, in order to avoid request header problems when using a canonical hostname. 