### PR TITLE
Configure sender_canonical map in postfix to specify Email sender

### DIFF
--- a/9/Dockerfile
+++ b/9/Dockerfile
@@ -7,12 +7,14 @@ FROM ubuntu:16.04
 COPY --from=0 /var/lib/openvas /var/lib/openvas
 COPY config/redis.config /etc/redis/redis.config
 COPY config/sasl_passwd_template /
+COPY config/sender_canonical_template /
 COPY config/main.cf_template /
 COPY config/ldapUserSync/* /ldapUserSync/
 COPY start /start
 
 ENV DEBIAN_FRONTEND=noninteractive \
     OV_PASSWORD=admin \
+    OV_SMTP_SENDER=root@openvas.localdomain \
     PUBLIC_HOSTNAME=openvas
 
 RUN apt-get update && \

--- a/9/config/main.cf_template
+++ b/9/config/main.cf_template
@@ -7,3 +7,4 @@ smtp_sasl_security_options = noanonymous
 smtp_use_tls = yes
 relayhost = [$OV_SMTP_HOSTNAME]:$OV_SMTP_PORT
 mynetworks = 0.0.0.0/0
+sender_canonical_maps = hash:/etc/postfix/sender_canonical

--- a/9/config/sender_canonical_template
+++ b/9/config/sender_canonical_template
@@ -1,0 +1,1 @@
+root $OV_SMTP_SENDER

--- a/9/start
+++ b/9/start
@@ -77,7 +77,7 @@ fi
 #
 # LDAP configuration (optional)
 #
-# Varaibles:
+# Variables:
 # - LDAP_HOST
 # - LDAP_BIND_DN
 # - LDAP_BASE_DN 
@@ -99,7 +99,7 @@ fi
 echo "Checking setup"
 ./openvas-check-setup --v9
 
-if [ -f /sasl_passwd_template ]; then
+if [ -n "$OV_SMTP_HOSTNAME" ]; then
   echo "Configuring postfix"
 
   set -o nounset
@@ -107,11 +107,14 @@ if [ -f /sasl_passwd_template ]; then
   set -o pipefail
 
   envsubst < "/sasl_passwd_template" > "/etc/postfix/sasl_passwd"
+  envsubst < "/sender_canonical_template" > "/etc/postfix/sender_canonical"
   envsubst < "/main.cf_template" > "/etc/postfix/main.cf"
 
   /usr/sbin/postmap /etc/postfix/sasl_passwd
+  /usr/sbin/postmap /etc/postfix/sender_canonical
 
   service postfix restart
+
 fi
 
 if [ -z "$BUILD" ]; then

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ docker run -d -p 443:443 -p 9390:9390 --name openvas -e LDAP_HOST=your.ldap.host
 ```
 
 #### Email Support
-To configure the postfix server, provide the following env variables at runtime: `OV_SMTP_HOSTNAME`, `OV_SMTP_PORT`, `OV_SMTP_USERNAME`, `OV_SMTP_KEY`
+To configure the postfix server, provide the following env variables at runtime: `OV_SMTP_HOSTNAME`, `OV_SMTP_PORT`, `OV_SMTP_USERNAME`, `OV_SMTP_KEY`, `OV_SMTP_SENDER`
 ```
-docker run -d -p 443:443 -e OV_SMTP_HOSTNAME=smtp.example.com -e OV_SMTP_PORT=587 -e OV_SMTP_USERNAME=username@example.com -e OV_SMTP_KEY=g0bBl3de3Go0k --name openvas mikesplain/openvas
+docker run -d -p 443:443 -e OV_SMTP_HOSTNAME=smtp.example.com -e OV_SMTP_PORT=587 -e OV_SMTP_USERNAME=username@example.com -e OV_SMTP_KEY=g0bBl3de3Go0k -e OV_SMTP_SENDER=username@example.com --name openvas mikesplain/openvas
 ```
 
 


### PR DESCRIPTION
By default postfix sends email using root@hostname.domain as sender; emails from this unknown domain are rejected by our mailserver.
This PR is to resolve that issue.
By configuring a sender_canonical map, one can overrule this standard sender using the environment variable $OV_SMTP_SENDER