### PR TITLE
Fixing docker compose

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,5 +1,5 @@
 ######################################################
-# Remember to Search and replace for "example.com" !
+# Remember to Search and replace for "scanner.security.twinhelix.co.uk" !
 ######################################################
 
 
@@ -15,7 +15,7 @@ http {
   
   server {
     listen   80;
-    server_name example.com;
+    server_name scanner.security.twinhelix.co.uk;
 
     location '/.well-known/acme-challenge' {
       default_type "text/plain";

--- a/conf/nginx_ssl.conf
+++ b/conf/nginx_ssl.conf
@@ -1,5 +1,5 @@
 ######################################################
-# Remember to Search and replace for "example.com" !
+# Remember to Search and replace for "scanner.security.twinhelix.co.uk" !
 ######################################################
 
 
@@ -17,15 +17,15 @@ http {
 
   server {
     listen 443 ssl http2;
-    server_name example.com;
+    server_name scanner.security.twinhelix.co.uk;
   
     ssl_protocols TLSv1.2;
     ssl_ciphers HIGH:!MEDIUM:!LOW:!aNULL:!NULL:!SHA;
     ssl_prefer_server_ciphers on;
     ssl_session_cache shared:SSL:10m;
   
-    ssl_certificate     /etc/letsencrypt/live/example.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+    ssl_certificate     /etc/letsencrypt/live/scanner.security.twinhelix.co.uk/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/scanner.security.twinhelix.co.uk/privkey.pem;
 
     proxy_set_header   Host                 $http_host;
     proxy_set_header   X-Forwarded-Proto    $scheme;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,8 @@ services:
       links:
         - nginx
       environment:
-        DOMAINS: example.com
-        EMAIL: webmaster@example.com
+        DOMAINS: scanner.security.twinhelix.co.uk
+        EMAIL: security@twinhelix.co.uk
         WEBROOT_PATH: /tmp/letsencrypt
         EXP_LIMIT: 30
         CHECK_FREQ: 30
@@ -51,10 +51,10 @@ services:
         - "./data/openvas:/var/lib/openvas/mgr/"
       environment:
         # CHANGE THIS !
-        OV_PASSWORD: securepassword41
+        OV_PASSWORD: ohthaeg6zi2Kae>mi]d
       labels:
-         deck-chores.dump.command: sh -c "greenbone-nvt-sync; openvasmd --rebuild --progress"
-         deck-chores.dump.interval: daily
+         deck-chores.syncupdate.command: sh -c "greenbone-nvt-sync; openvasmd --rebuild --progress; greenbone-certdata-sync; greenbone-scapdata-sync; openvasmd --update --verbose --progress; /etc/init.d/openvas-manager restart; /etc/init.d/openvas-scanner restart"
+         deck-chores.syncupdate.interval: daily
   # Daily updates to openvas
   cron:
       restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,8 @@ services:
         OV_SMTP_PORT: 587
         OV_SMTP_USERNAME: scanner@mg.twinhelix.co.uk
         OV_SMTP_KEY: 139328732d4f4f7e1197030b5e7136ca-713d4f73-38510009
+        VIRTUAL_PROTO: https
+        VIRTUAL_PORT: 443
       labels:
          deck-chores.syncupdate.command: sh -c "greenbone-nvt-sync; openvasmd --rebuild --progress; greenbone-certdata-sync; greenbone-scapdata-sync; openvasmd --update --verbose --progress; /etc/init.d/openvas-manager restart; /etc/init.d/openvas-scanner restart"
          deck-chores.syncupdate.interval: daily

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,9 +47,9 @@ services:
         - openvas_data:/var/lib/openvas/mgr
       environment:
         OV_PASSWORD: ohthaeg6zi2Kae>mi]d
-        VIRTUAL_HOST: scanner.security.twinhelix.co.uk
-        PUBLIC_HOSTNAME: scanner.security.twinhelix.co.uk
-        LETSENCRYPT_HOST: scanner.security.twinhelix.co.uk
+        VIRTUAL_HOST: scanner.twinhelix.co.uk
+        PUBLIC_HOSTNAME: scanner.twinhelix.co.uk
+        LETSENCRYPT_HOST: scanner.twinhelix.co.uk
         OV_SMTP_HOSTNAME: smtp.eu.mailgun.org
         OV_SMTP_PORT: 587
         OV_SMTP_USERNAME: scanner@mg.twinhelix.co.uk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '3'
+# Please remember to find and replace any values below inbetween < > and in ALLCAPS
 
 services:
 
@@ -23,7 +24,7 @@ services:
     image: jrcs/letsencrypt-nginx-proxy-companion
     container_name: nginx-proxy-le
     environment:
-      - "DEFAULT_EMAIL=systems@twinhelix.co.uk"
+      - "DEFAULT_EMAIL=<EMAIL_ADDRESS_FOR_LETSENCRYPT>"
       - "NGINX_PROXY_CONTAINER=nginx-proxy"
 
     volumes:
@@ -46,18 +47,18 @@ services:
       volumes:
         - openvas_data:/var/lib/openvas/mgr
       environment:
-        OV_PASSWORD: ohthaeg6zi2Kae>mi]d
-        VIRTUAL_HOST: scanner.twinhelix.co.uk
-        PUBLIC_HOSTNAME: scanner.twinhelix.co.uk
-        LETSENCRYPT_HOST: scanner.twinhelix.co.uk
-        OV_SMTP_HOSTNAME: smtp.eu.mailgun.org
+        OV_PASSWORD: <CHANGE_TO_REAL_PASSWORD>
+        VIRTUAL_HOST: <SET_TO_FQDN_OF_INSTANCE>
+        PUBLIC_HOSTNAME: <SET_TO_FQDN_OF_INSTANCE>
+        LETSENCRYPT_HOST: <SET_TO_FQDN_OF_INSTANCE>
+        OV_SMTP_HOSTNAME: <SMTP_HOSTNAME>
         OV_SMTP_PORT: 587
-        OV_SMTP_USERNAME: scanner@mg.twinhelix.co.uk
-        OV_SMTP_KEY: 139328732d4f4f7e1197030b5e7136ca-713d4f73-38510009
-        VIRTUAL_PROTO: https
+        OV_SMTP_USERNAME: <SMTP_USERNAME>
+        OV_SMTP_KEY: <SMTP_PASSWORD>
+        VIRTUAL_PROTO: https # Required by nginx-proxy-le because gsad presents on port 443/https
         VIRTUAL_PORT: 443
       labels:
-         deck-chores.syncupdate.command: sh -c "greenbone-nvt-sync; openvasmd --rebuild --progress; greenbone-certdata-sync; greenbone-scapdata-sync; openvasmd --update --verbose --progress; /etc/init.d/openvas-manager restart; /etc/init.d/openvas-scanner restart"
+         deck-chores.syncupdate.command: sh -c "greenbone-nvt-sync; openvasmd --rebuild --progress"
          deck-chores.syncupdate.interval: daily
       depends_on:
         - letsencrypt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,46 +1,42 @@
 version: '3'
+
 services:
-  # This Nginx will be the first to start, and it will serve the redirect as well as ACME verification
-  nginx:
-      image: nginx:alpine
-      restart: always
-      hostname: nginx
-      ports:
-        - "80:80"
-      links:
-        - openvas
-      volumes:
-        - ./conf/nginx.conf:/etc/nginx/nginx.conf:ro
-        - ./data/letsencrypt:/etc/letsencrypt
-        - ./data/letsencrypt-www:/tmp/letsencrypt
-  # This Nginx requires the certificates to exist, otherwise will fail
-  nginx_ssl:
-      image: nginx:alpine
-      restart: always
-      hostname: nginx_ssl
-      ports:
-        - "443:443"
-      links:
-        - openvas
-        - letsencrypt
-      volumes:
-        - ./conf/nginx_ssl.conf:/etc/nginx/nginx.conf:ro
-        - ./data/letsencrypt:/etc/letsencrypt
-        - ./data/letsencrypt-www:/tmp/letsencrypt
+
+  nginx-proxy:
+    image: jwilder/nginx-proxy
+    container_name: nginx-proxy
+    ports:
+      - "80:80"
+      - "443:443"
+    # environment:
+    #   - "ENABLE_IPV6=true"
+    volumes:
+      - conf:/etc/nginx/conf.d
+      - vhost:/etc/nginx/vhost.d
+      - html:/usr/share/nginx/html
+      - dhparam:/etc/nginx/dhparam
+      - certs:/etc/nginx/certs:ro
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+    
+
   letsencrypt:
-      restart: always
-      image: kvaps/letsencrypt-webroot
-      volumes:
-        - ./data/letsencrypt:/etc/letsencrypt
-        - ./data/letsencrypt-www:/tmp/letsencrypt
-      links:
-        - nginx
-      environment:
-        DOMAINS: scanner.security.twinhelix.co.uk
-        EMAIL: security@twinhelix.co.uk
-        WEBROOT_PATH: /tmp/letsencrypt
-        EXP_LIMIT: 30
-        CHECK_FREQ: 30
+    image: jrcs/letsencrypt-nginx-proxy-companion
+    container_name: nginx-proxy-le
+    environment:
+      - "DEFAULT_EMAIL=systems@twinhelix.co.uk"
+      - "NGINX_PROXY_CONTAINER=nginx-proxy"
+
+    volumes:
+      - certs:/etc/nginx/certs:rw
+      - conf:/etc/nginx/conf.d
+      - vhost:/etc/nginx/vhost.d
+      - html:/usr/share/nginx/html
+      - dhparam:/etc/nginx/dhparam
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+    depends_on:
+      - nginx-proxy
+
   openvas:
       restart: always
       image: mikesplain/openvas
@@ -48,16 +44,32 @@ services:
       expose:
         - "443"
       volumes:
-        - "./data/openvas:/var/lib/openvas/mgr/"
+        - openvas_data:/var/lib/openvas/mgr
       environment:
-        # CHANGE THIS !
         OV_PASSWORD: ohthaeg6zi2Kae>mi]d
+        VIRTUAL_HOST: scanner.security.twinhelix.co.uk
+        PUBLIC_HOSTNAME: scanner.security.twinhelix.co.uk
+        LETSENCRYPT_HOST: scanner.security.twinhelix.co.uk
+        OV_SMTP_HOSTNAME: smtp.eu.mailgun.org
+        OV_SMTP_PORT: 587
+        OV_SMTP_USERNAME: scanner@mg.twinhelix.co.uk
+        OV_SMTP_KEY: 139328732d4f4f7e1197030b5e7136ca-713d4f73-38510009
       labels:
          deck-chores.syncupdate.command: sh -c "greenbone-nvt-sync; openvasmd --rebuild --progress; greenbone-certdata-sync; greenbone-scapdata-sync; openvasmd --update --verbose --progress; /etc/init.d/openvas-manager restart; /etc/init.d/openvas-scanner restart"
          deck-chores.syncupdate.interval: daily
+      depends_on:
+        - letsencrypt
   # Daily updates to openvas
   cron:
       restart: always
       image: funkyfuture/deck-chores
       volumes:
         - "/var/run/docker.sock:/var/run/docker.sock"
+volumes:
+  openvas_data:
+  conf:
+  vhost:
+  html:
+  dhparam:
+  certs:
+


### PR DESCRIPTION
I updated the nginx to use the jwilder/nginx-proxy image, with LetsEncrypt automation.  
There's a few new Environment Variables in docker-compose.yml to update: 
letsencrypt:
DEFAULT_EMAIL
openvas:
OV_PASSWORD
VIRTUAL_HOST
PUBLIC_HOSTNAME
LETSENCRYPT_HOST
OV_SMTP_HOSTNAME
OV_SMTP_USERNAME
OV_SMTP_KEY

And it now defines volumes for the letsencrypt/nginx config, plus openvas_data