### PR TITLE
Fix test.sh verification

### DIFF
--- a/9/Dockerfile
+++ b/9/Dockerfile
@@ -517,10 +517,6 @@ RUN wget -q https://github.com/Arachni/arachni/releases/download/v1.5.1/arachni-
     rm -rf arachni*
 
 RUN mkdir -p /var/run/redis && \
-    wget -q --no-check-certificate \
-    https://raw.githubusercontent.com/kurobeats/OpenVas-Management-Scripts/master/openvas-check-setup \
-      -O /openvas-check-setup && \
-    chmod +x /openvas-check-setup && \
     sed -i 's/DAEMON_ARGS=""/DAEMON_ARGS="-a 0.0.0.0 --client-watch-interval=0"/' /etc/init.d/openvas-manager && \
     sed -i 's/DAEMON_ARGS=""/DAEMON_ARGS="--mlisten 127.0.0.1 -m 9390 --gnutls-priorities=SECURE128:-AES-128-CBC:-CAMELLIA-128-CBC:-VERS-SSL3.0:-VERS-TLS1.0"/' /etc/init.d/openvas-gsa && \
     sed -i '/^\[ -n "$HTTP_STS_MAX_AGE" \]/a[ -n "$PUBLIC_HOSTNAME" ] && DAEMON_ARGS="$DAEMON_ARGS --allow-header-host=$PUBLIC_HOSTNAME"' /etc/init.d/openvas-gsa && \

--- a/9/start
+++ b/9/start
@@ -96,8 +96,8 @@ then
   /ldapUserSync/ldapUserSync.py
 fi
 
-echo "Checking setup"
-./openvas-check-setup --v9
+echo "Checking certificates"
+openvas-manage-certs -V
 
 if [ -f /sasl_passwd_template ]; then
   echo "Configuring postfix"

--- a/9/test.sh
+++ b/9/test.sh
@@ -3,7 +3,7 @@
 docker run -d -p 8443:443 --name openvas9 openvas9
 
 echo "Waiting for startup to complete..."
-until docker logs openvas9 | grep -E 'It seems like your OpenVAS-9 installation is'; do
+until docker logs openvas9 | grep -E 'Your OpenVAS certificate infrastructure passed validation'; do
   echo .
   sleep 5
 done

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ docker run -d -p 443:443 --name openvas mikesplain/openvas
 docker run -d -p 443:443 --name openvas mikesplain/openvas:9
 ```
 
-This will grab the container from the docker registry and start it up.  Openvas startup can take some time (4-5 minutes while NVT's are scanned and databases rebuilt), so be patient.  Once you see a `It seems like your OpenVAS-9 installation is OK.` process in the logs, the web ui is good to go.  Goto `https://<machinename>`
+This will grab the container from the docker registry and start it up.  Openvas startup can take some time (4-5 minutes while NVT's are scanned and databases rebuilt), so be patient.  Once you see a `OK: Your OpenVAS certificate infrastructure passed validation.` process in the logs, the web ui is good to go.  Goto `https://<machinename>`
 
 ```
 Username: admin


### PR DESCRIPTION
**Problem**

openvas-check-setup is out of date and fails validating certificates. The failure is seen in the travis ci build failure logs - https://travis-ci.org/github/mikesplain/openvas-docker/builds/676746746

```
Step 1: Checking OpenVAS Scanner ... 

        OK: OpenVAS Scanner is present in version 5.1.3.

        OK: OpenVAS Scanner CA Certificate is present as .

dirname: missing operand

Try 'dirname --help' for more information.

        ERROR: No server certificate file of OpenVAS Scanner found.

        FIX: Run 'openvas-mkcert -f -q'.

 ERROR: Your OpenVAS-9 installation is not yet complete!
```

**Proposed Solution**

openvas-check-setup is no longer developed (https://community.greenbone.net/t/where-can-i-download-openvas-check-setup/936). The proposed solution is to stop using openvas-check-setup. I have replaced it with `openvas-manage-certs -V` to at least have a validation check on certificates.

**Testing**

build output contains the new `openvas-manage-certs -V` check
```
Checking certificates
OK: Directory for keys (/var/lib/openvas/private/CA) exists.
OK: Directory for certificates (/var/lib/openvas/CA) exists.
OK: CA key found in /var/lib/openvas/private/CA/cakey.pem
OK: CA certificate found in /var/lib/openvas/CA/cacert.pem
OK: CA certificate verified.
OK: Certificate /var/lib/openvas/CA/servercert.pem verified.
OK: Certificate /var/lib/openvas/CA/clientcert.pem verified.

OK: Your OpenVAS certificate infrastructure passed validation.
```

`./test.sh` now passes and outputs `Greenbone started successfully!`