### PR TITLE
changed letsencryt image from kvaps/letsencrypt-webroot to recommende…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,10 @@ services:
         - ./data/letsencrypt-www:/tmp/letsencrypt
   letsencrypt:
       restart: always
-      image: kvaps/letsencrypt-webroot
+      image: vdhpieter/letsencrypt-webroot
       volumes:
+        - /etc/localtime:/etc/localtime:ro
+        - /var/run/docker.sock:/var/run/docker.sock
         - ./data/letsencrypt:/etc/letsencrypt
         - ./data/letsencrypt-www:/tmp/letsencrypt
       links:
@@ -41,6 +43,7 @@ services:
         WEBROOT_PATH: /tmp/letsencrypt
         EXP_LIMIT: 30
         CHECK_FREQ: 30
+        STAGING: 0
   openvas:
       restart: always
       image: mikesplain/openvas
@@ -52,12 +55,13 @@ services:
       environment:
         # CHANGE THIS !
         OV_PASSWORD: securepassword41
+        PUBLIC_HOSTNAME: example.com
       labels:
          deck-chores.dump.command: sh -c "greenbone-nvt-sync; openvasmd --rebuild --progress"
          deck-chores.dump.interval: daily
   # Daily updates to openvas
   cron:
       restart: always
-      image: funkyfuture/deck-chores
+      image: funkyfuture/deck-chores:1.0.0
       volumes:
         - "/var/run/docker.sock:/var/run/docker.sock"


### PR DESCRIPTION
### Problem
The old docker-compose.yml wasn't able to start a working environment anymore.

### Solution
I changed the letsencrypt image to the recommended replacement fork.
I also added some new variables to make openvas work right out of the box with a fqdn on a public webserver.
The image funkyfuture/deck-chores doesn't has a latest tag anymore so I had to choose a fix version tag