### PR TITLE
Update Ubuntu base image to newest LTS

### DIFF
--- a/9/Dockerfile
+++ b/9/Dockerfile
@@ -2,7 +2,7 @@
 # to sync 1.9 Gb of data from OpenVAS.
 FROM mikesplain/openvas
 
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 COPY --from=0 /var/lib/openvas /var/lib/openvas
 COPY config/redis.config /etc/redis/redis.config


### PR DESCRIPTION
The 20.04 base images has improvements to Openssl and other tools that will be useful.